### PR TITLE
Add isIddle() to mocked transport 

### DIFF
--- a/nodemailer-mock.js
+++ b/nodemailer-mock.js
@@ -40,6 +40,7 @@ function NodemailerMock(nodemailer) {
   let _shouldFail = false;
   let _shouldFailOnce = false;
   let _shouldFailCheck = null;
+  let _shouldAreIdle = true;
 
   // Determine if the test should return success or failure
   const determineResponseSuccess = function determineResponseSuccess(email) {
@@ -146,7 +147,7 @@ function NodemailerMock(nodemailer) {
       },
 
       isIdle: () => {
-        return true;
+          return _shouldAreIdle;
       },
 
       // the options this transport was created with
@@ -173,6 +174,11 @@ function NodemailerMock(nodemailer) {
      * @param  {boolean} isFail true will return errors, false will return successes
      */
     setShouldFail: (isFail) => (_shouldFail = isFail),
+    /**
+     * determine if pool should return iddle 
+     * @param  {boolean} isIdle true will simulates iddle state 
+     */
+    setShouldAreIdle: (isIdle) => (_shouldAreIdle = isIdle),
     /**
      * determine if transport.verify() should be mocked or not
      * @param  {boolean} isMocked if the function should be mocked
@@ -206,6 +212,7 @@ function NodemailerMock(nodemailer) {
       _userPlugins = { ..._userPluginsDefault };
       _sentMail = [];
       _shouldFail = _shouldFailOnce = false;
+      _shouldAreIdle = false;
       _successResponse = messages.success_response;
       _failResponse = messages.fail_response;
       _mockedVerify = true;

--- a/nodemailer-mock.js
+++ b/nodemailer-mock.js
@@ -145,6 +145,10 @@ function NodemailerMock(nodemailer) {
         debug('Subscribe to event' + name);
       },
 
+      isIdle: () => {
+        return true;
+      },
+
       // the options this transport was created with
       mock: {
         options,

--- a/nodemailer-mock.js
+++ b/nodemailer-mock.js
@@ -140,6 +140,11 @@ function NodemailerMock(nodemailer) {
 
         return;
       },
+
+      on: (name) => {
+        debug('Subscribe to event' + name);
+      },
+
       // the options this transport was created with
       mock: {
         options,

--- a/test/nodemailer-mock-tests.js
+++ b/test/nodemailer-mock-tests.js
@@ -61,6 +61,12 @@ describe('Testing nodemailer-mock...', () => {
       plugins = transport.mock.getPlugins()[''];
       should(plugins).equal(undefined);
     });
+
+    it('should emulate iddle status', () => {
+        should(transport.isIdle()).equal(false); 
+        mocked.mock.setShouldAreIdle(true);
+        should(transport.isIdle()).equal(true); 
+    });
   });
 
   describe('nodestyle callback api', () => {


### PR DESCRIPTION
Add methods `on` and `isIddle` to transport to emulate iddle state.