### PR TITLE
Add close() to mocked transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# VSCode
+.history
+
 # Logs
 logs
 *.log

--- a/nodemailer-mock.js
+++ b/nodemailer-mock.js
@@ -130,6 +130,14 @@ function NodemailerMock(nodemailer) {
         return transport.verify(callback);
       },
 
+      close: () => {
+        debug('transport.close');
+        if (transport) {
+          transport.close();
+        }
+        return;
+      },
+
       use: (step, plugin) => {
         const stepId = (step || '').toString();
         if (!Object.prototype.hasOwnProperty.call(_userPlugins, stepId)) {

--- a/nodemailer-mock.js
+++ b/nodemailer-mock.js
@@ -33,6 +33,8 @@ function NodemailerMock(nodemailer) {
     stream: [],
   };
   let _userPlugins = { ..._userPluginsDefault };
+  // transport.close call count
+  let _closeCallCount = 0;
   // Sent mail cache
   let _sentMail = [];
 
@@ -132,6 +134,7 @@ function NodemailerMock(nodemailer) {
 
       close: () => {
         debug('transport.close');
+        _closeCallCount++;
         if (transport) {
           transport.close();
         }
@@ -197,6 +200,11 @@ function NodemailerMock(nodemailer) {
      * @return {Object[]} an array of emails
      */
     getSentMail: () => _sentMail,
+    /**
+     * get the number of times the close() function has been called
+     * @returns {int} number of times close() has been called
+     */
+    getCloseCallCount: () => _closeCallCount,
 
     /**
      * reset mock values to defaults
@@ -204,6 +212,7 @@ function NodemailerMock(nodemailer) {
     reset: () => {
       _userPlugins = { ..._userPluginsDefault };
       _sentMail = [];
+      _closeCallCount = 0;
       _shouldFail = _shouldFailOnce = false;
       _successResponse = messages.success_response;
       _failResponse = messages.fail_response;

--- a/test/nodemailer-mock-tests.js
+++ b/test/nodemailer-mock-tests.js
@@ -61,6 +61,16 @@ describe('Testing nodemailer-mock...', () => {
       plugins = transport.mock.getPlugins()[''];
       should(plugins).equal(undefined);
     });
+
+    it('should succeed for email sending before and after close', async () => {
+      const info = await transport.sendMail('Email');
+      info.response.should.equal(messages.success_response);
+
+      transport.close();
+
+      const info2 = await transport.sendMail('Email2');
+      info2.response.should.equal(messages.success_response);
+    });
   });
 
   describe('nodestyle callback api', () => {
@@ -70,19 +80,6 @@ describe('Testing nodemailer-mock...', () => {
         should(err).equal(null);
         info.response.should.equal(messages.success_response);
         done();
-      });
-    });
-
-    it('should succeed for email sending before and after close', (done) => {
-      transport.sendMail('Email', (err, info) => {
-        should(err).equal(null);
-        info.response.should.equal(messages.success_response);
-        transport.close();
-        transport.sendMail('Email2', (err, info) => {
-          should(err).equal(null);
-          info.response.should.equal(messages.success_response);
-          done();
-        });
       });
     });
 
@@ -235,17 +232,6 @@ describe('Testing nodemailer-mock...', () => {
       });
     });
 
-    it('should succeed for email sending before and after close', (done) => {
-      transport.sendMail('Email').then((info) => {
-        info.response.should.equal(messages.success_response);
-        transport.close();
-        transport.sendMail('Email2').then((info) => {
-          info.response.should.equal(messages.success_response);
-          done();
-        });
-      });
-    });
-
     it('should have the sent email available in the mock.getSentMail()', (done) => {
       // Look for this value in the sentmail cache
       const email = 'Check for this value';
@@ -370,16 +356,6 @@ describe('Testing nodemailer-mock...', () => {
     it('should succeed for email sending', async () => {
       const info = await transport.sendMail('Email');
       info.response.should.equal(messages.success_response);
-    });
-
-    it('should succeed for email sending before and after close', async () => {
-      const info = await transport.sendMail('Email');
-      info.response.should.equal(messages.success_response);
-
-      transport.close();
-
-      const info2 = await transport.sendMail('Email2');
-      info2.response.should.equal(messages.success_response);
     });
 
     it('should have the sent email available in the mock.getSentMail()', async () => {

--- a/test/nodemailer-mock-tests.js
+++ b/test/nodemailer-mock-tests.js
@@ -73,6 +73,19 @@ describe('Testing nodemailer-mock...', () => {
       });
     });
 
+    it('should succeed for email sending before and after close', (done) => {
+      transport.sendMail('Email', (err, info) => {
+        should(err).equal(null);
+        info.response.should.equal(messages.success_response);
+        transport.close();
+        transport.sendMail('Email2', (err, info) => {
+          should(err).equal(null);
+          info.response.should.equal(messages.success_response);
+          done();
+        });
+      });
+    });
+
     it('should have the sent email available in the mock.getSentMail()', (done) => {
       // Look for this value in the sentmail cache
       const email = 'Check for this value';
@@ -222,6 +235,17 @@ describe('Testing nodemailer-mock...', () => {
       });
     });
 
+    it('should succeed for email sending before and after close', (done) => {
+      transport.sendMail('Email').then((info) => {
+        info.response.should.equal(messages.success_response);
+        transport.close();
+        transport.sendMail('Email2').then((info) => {
+          info.response.should.equal(messages.success_response);
+          done();
+        });
+      });
+    });
+
     it('should have the sent email available in the mock.getSentMail()', (done) => {
       // Look for this value in the sentmail cache
       const email = 'Check for this value';
@@ -346,6 +370,16 @@ describe('Testing nodemailer-mock...', () => {
     it('should succeed for email sending', async () => {
       const info = await transport.sendMail('Email');
       info.response.should.equal(messages.success_response);
+    });
+
+    it('should succeed for email sending before and after close', async () => {
+      const info = await transport.sendMail('Email');
+      info.response.should.equal(messages.success_response);
+
+      transport.close();
+
+      const info2 = await transport.sendMail('Email2');
+      info2.response.should.equal(messages.success_response);
     });
 
     it('should have the sent email available in the mock.getSentMail()', async () => {

--- a/test/nodemailer-mock-tests.js
+++ b/test/nodemailer-mock-tests.js
@@ -66,7 +66,9 @@ describe('Testing nodemailer-mock...', () => {
       const info = await transport.sendMail('Email');
       info.response.should.equal(messages.success_response);
 
+      should(mocked.mock.getCloseCallCount()).equal(0);
       transport.close();
+      should(mocked.mock.getCloseCallCount()).equal(1);
 
       const info2 = await transport.sendMail('Email2');
       info2.response.should.equal(messages.success_response);


### PR DESCRIPTION
Adds method `close()` to mocked transport in order to allow closing of pooled connections.  
Additionally adds `getCloseCallCount()` to `mocked.mock` which returns the number of times the `close()` method has been called. This allows testing whether the nodemailer transport gets closed to often.