### PR TITLE
Support nodemailer 9.x as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "debug": "^4.4.3"
   },
   "peerDependencies": {
-    "nodemailer": "^6.x || ^7.x || ^8.x"
+    "nodemailer": "^6.x || ^7.x || ^8.x || ^9.x"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.2",


### PR DESCRIPTION
Suggested `peerDependencies` change to support the newly released nodemailer 9.x lineage per https://github.com/doublesharp/nodemailer-mock/issues/28 